### PR TITLE
🛠️  Add Dependabot configuration for package updates using `uv`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: ⬆

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,14 +1,18 @@
 # Release Notes
 
+## Latest Changes
+
+- Add Dependabot configuration for package updates using `uv`. PR [#2](https://github.com/msamsami/fastapi-maintenance/pull/2) by [@msamsami](https://github.com/msamsami).
+
 ## 0.0.2
 
 ### Fixes
 
-- Fix compatibility with different versions of Pydantic.
+- Fix compatibility with different versions of Pydantic. PR [#1](https://github.com/msamsami/fastapi-maintenance/pull/1) by [@msamsami](https://github.com/msamsami).
 
 ### Internal
 
-- Add `.python-version` file for development purposes.
+- Add `.python-version` file for development purposes. PR [#1](https://github.com/msamsami/fastapi-maintenance/pull/1) by [@msamsami](https://github.com/msamsami).
 
 ## 0.0.1
 


### PR DESCRIPTION
This PR adds Dependabot configuration to automate dependency updates using the `uv` package manager. The configuration sets up daily checks for new package versions, helping to keep dependencies up-to-date and secure with minimal manual effort.