### PR TITLE
📝 Fix incorrect references to “callback” instead of “handler” in docs

### DIFF
--- a/docs/tutorial/advanced-usage.md
+++ b/docs/tutorial/advanced-usage.md
@@ -21,7 +21,7 @@ configure_backend("file", file_path="maintenance_mode.txt")
 
 app = FastAPI()
 
-# Custom response callback
+# Custom response handler
 async def custom_response(request: Request) -> JSONResponse:
     return JSONResponse(
         content={
@@ -33,14 +33,14 @@ async def custom_response(request: Request) -> JSONResponse:
         headers={"Retry-After": "1800"}
     )
 
-# Custom exemption callback
+# Custom exemption handler
 def is_exempt(request: Request) -> bool:
     # Allow monitoring tools
     if request.headers.get("User-Agent", "").startswith("Monitoring"):
         return True
     return False
 
-# Add middleware with custom callbacks
+# Add middleware with custom handlers
 app.add_middleware(
     MaintenanceModeMiddleware,
     response_handler=custom_response,

--- a/docs/tutorial/custom-responses.md
+++ b/docs/tutorial/custom-responses.md
@@ -69,7 +69,7 @@ async def custom_maintenance_response(request: Request) -> JSONResponse:
 
 app.add_middleware(
     MaintenanceModeMiddleware,
-    response_callback=custom_maintenance_response
+    response_handler=custom_maintenance_response
 )
 ```
 
@@ -138,7 +138,7 @@ async def html_maintenance_page(request: Request) -> HTMLResponse:
 
 app.add_middleware(
     MaintenanceModeMiddleware,
-    response_callback=html_maintenance_page
+    response_handler=html_maintenance_page
 )
 ```
 
@@ -173,7 +173,7 @@ async def content_negotiated_response(request: Request) -> Response:
 
 app.add_middleware(
     MaintenanceModeMiddleware,
-    response_callback=content_negotiated_response
+    response_handler=content_negotiated_response
 )
 ```
 
@@ -201,7 +201,7 @@ async def template_maintenance_page(request: Request) -> Response:
 
 app.add_middleware(
     MaintenanceModeMiddleware,
-    response_callback=template_maintenance_page
+    response_handler=template_maintenance_page
 )
 ```
 
@@ -256,6 +256,6 @@ async def path_aware_response(request: Request) -> JSONResponse:
 
 app.add_middleware(
     MaintenanceModeMiddleware,
-    response_callback=path_aware_response
+    response_handler=path_aware_response
 )
 ```


### PR DESCRIPTION
Under the [Custom responses](https://msamsami.github.io/fastapi-maintenance/tutorial/custom-responses/) section of the docs we are referencing `response_callback` as a parameter to **MaintenanceModeMiddleware** instead of `response_handler`.

This PR is to fix the typo error.