### PR TITLE
🐛 Fix bug: FastAPI documentation endpoints inaccessible during maintenance mode

### DIFF
--- a/docs/tutorial/custom-exemptions.md
+++ b/docs/tutorial/custom-exemptions.md
@@ -2,6 +2,13 @@
 
 While decorators provide a simple way to exempt specific routes from maintenance mode, more complex scenarios often require custom exemption logic. The `exempt_handler` parameter of the middleware allows you to implement custom rules that can consider any aspect of the incoming request.
 
+<details open>
+<summary>Note</summary>
+
+By default, FastAPI's built-in documentation endpoints (<code>/docs</code>, <code>/redoc</code>, <code>/openapi.json</code>, <code>/docs/oauth2-redirect</code>) are automatically exempted from maintenance mode to keep API documentation accessible. This built-in behavior works alongside any custom exemption handler you define.
+
+</details>
+
 ## Basic Usage
 
 Here's a simple example that exempts health check endpoints and requests with an admin key from maintenance mode:
@@ -26,6 +33,12 @@ app.add_middleware(
     MaintenanceModeMiddleware,
     exempt_handler=is_exempt
 )
+
+# Result during maintenance:
+# ✅ /docs, /redoc, /openapi.json, /docs/oauth2-redirect (automatically exempt)
+# ✅ /health/* (custom exemption)
+# ✅ Requests with X-Admin-Key header (custom exemption)
+# ❌ Other endpoints return 503
 ```
 
 ## Handler Function Requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,19 +111,26 @@ select = [
     "I",  # isort
     "B",  # flake8-bugbear
     "C4",  # flake8-comprehensions
+    # Compatibility with ruff formatter
+    "E501",
+    "ISC001",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "W191",
 ]
 ignore = [
     "E501",  # line too long, handled by black
     "B008",  # do not perform function calls in argument defaults
     "C901",  # too complex
-    "W191",  # indentation contains tabs
 ]
 
 [tool.isort]
 atomic = true
 profile = "black"
 skip_gitignore = true
-known_first_party = ["black", "blib2to3", "blackd", "_black_version"]
+known_first_party = ["fastapi_maintenance"]
 
 [tool.uv]
 default-groups = ["dev", "docs"]

--- a/src/fastapi_maintenance/_handlers.py
+++ b/src/fastapi_maintenance/_handlers.py
@@ -1,0 +1,28 @@
+"""
+Built-in handlers for FastAPI maintenance mode.
+"""
+
+from starlette.requests import Request
+
+
+def exempt_docs_endpoints(request: Request) -> bool:
+    """Exempt FastAPI's built-in documentation endpoints from maintenance mode.
+
+    This handler exempts the following FastAPI built-in endpoints:
+    - /docs - Swagger UI interactive documentation
+    - /redoc - ReDoc alternative documentation
+    - /openapi.json - OpenAPI schema specification
+    - /docs/oauth2-redirect - OAuth2 redirect for Swagger UI
+
+    Args:
+        request: The incoming request.
+
+    Returns:
+        True if the request should be exempt from maintenance mode, False otherwise.
+    """
+    path = request.url.path
+
+    # FastAPI built-in documentation endpoints
+    docs_endpoints = ["/docs", "/redoc", "/openapi.json", "/docs/oauth2-redirect"]
+
+    return path in docs_endpoints

--- a/src/fastapi_maintenance/middleware.py
+++ b/src/fastapi_maintenance/middleware.py
@@ -30,6 +30,7 @@ from ._constants import (
 )
 from ._context import is_maintenance_override_ctx_active
 from ._core import get_maintenance_mode, register_middleware_backend
+from ._handlers import exempt_docs_endpoints
 from .backends import BaseStateBackend
 
 P = ParamSpec("P")
@@ -158,6 +159,11 @@ class MaintenanceModeMiddleware(BaseHTTPMiddleware):
         Returns:
             True if the request is exempt, False otherwise.
         """
+        # Built-in exemption: FastAPI documentation endpoints are always exempt
+        if exempt_docs_endpoints(request):
+            return True
+
+        # Custom exemption handler
         if self.exempt_handler is not None:
             if asyncio.iscoroutinefunction(self.exempt_handler):
                 if await self.exempt_handler(request):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,5 +1,7 @@
 import os
+import sys
 from pathlib import Path as SyncPath
+from unittest.mock import patch
 
 import pytest
 from anyio import Path
@@ -240,3 +242,20 @@ async def test_local_file_backend_requires_file_path():
     backend = _get_backend("file", file_path=file_path)
     assert isinstance(backend, LocalFileBackend)
     assert backend.file_path == file_path
+
+
+def test_fallback_imports():
+    """Test that Pydantic fallback imports work when main imports fail."""
+
+    # Remove the module to force reimport
+    if "fastapi_maintenance.backends" in sys.modules:
+        del sys.modules["fastapi_maintenance.backends"]
+
+    # Mock the pydantic.v1 modules to not exist
+    with patch.dict("sys.modules", {"pydantic.v1": None, "pydantic.v1.errors": None, "pydantic.v1.validators": None}):
+        # This will trigger the except block and use fallback imports
+        import fastapi_maintenance.backends
+
+    # Verify the module loaded and has the expected attributes
+    assert hasattr(fastapi_maintenance.backends, "BoolError")
+    assert hasattr(fastapi_maintenance.backends, "bool_validator")


### PR DESCRIPTION
🐛 Fix bug: FastAPI documentation endpoints inaccessible during maintenance mode
🔧 Improve test coverage
🛠️ Update `pyproject.toml` file by adding new Ruff linting rules and fixing `isort`'s `known_first_party` attribute