### PR TITLE
🛠️ Remove Dependabot configuration (`dependabot.yml`) as it doesn't fully support `uv`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: ⬆


### PR DESCRIPTION
🛠️ Remove Dependabot configuration (`dependabot.yml`) as it doesn't fully support `uv`